### PR TITLE
chore: do load test locally

### DIFF
--- a/cypress/performance/performance-testing-dload.jmx
+++ b/cypress/performance/performance-testing-dload.jmx
@@ -29,7 +29,7 @@
         <collectionProp name="Arguments.arguments">
           <elementProp name="base_url" elementType="Argument">
             <stringProp name="Argument.name">base_url</stringProp>
-            <stringProp name="Argument.value">serverest.dev</stringProp>
+            <stringProp name="Argument.value">localhost:3000</stringProp>
             <stringProp name="Argument.metadata">=</stringProp>
           </elementProp>
           <elementProp name="protocol" elementType="Argument">


### PR DESCRIPTION
Serverest.dev doesn't allow load tests. Is necessary to run the test locally.

See more: https://github.com/ServeRest/ServeRest#teste-de-carga